### PR TITLE
Demonstrate alternative way to structure navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@eva-design/eva": "1.0.0",
-    "expo": "^33.0.4",
+    "expo": "^33.0.5",
     "expo-analytics": "^1.0.8",
     "expo-camera": "^5.0.1",
     "expo-constants": "^5.0.1",

--- a/src/core/navigation/navigationParams.tsx
+++ b/src/core/navigation/navigationParams.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import { Alert } from 'react-native';
-import {
-  NavigationParams,
-  NavigationScreenProps,
-} from 'react-navigation';
+import { NavigationParams, NavigationScreenProps } from 'react-navigation';
 import { EcommerceHeader } from '@src/components/ecommerce';
 import { MenuContainer } from '@src/containers/menu';
 import { ArrowIosBackFill } from '@src/assets/icons';
 import { TopNavigationBar } from './components/topNavigationBar.component';
-import {
-  getCurrentRouteState,
-  NavigationRouteState,
-} from './routeUtil';
+import { getCurrentRouteState, NavigationRouteState } from './routeUtil';
 
 export type TopNavigationElement = React.ReactElement<any>;
 export type BottomNavigationElement = React.ReactElement<any>;
@@ -21,7 +15,9 @@ export interface TopNavigationParams extends NavigationParams {
 }
 
 export interface BottomNavigationParams extends NavigationParams {
-  bottomNavigation: (props: NavigationScreenProps) => BottomNavigationElement | null;
+  bottomNavigation: (
+    props: NavigationScreenProps
+  ) => BottomNavigationElement | null;
 }
 
 const MenuTopNavigationParams: TopNavigationParams = {
@@ -41,8 +37,8 @@ const MenuTopNavigationParams: TopNavigationParams = {
   },
 };
 
-const EcommerceMenuTopNavigationParams: TopNavigationParams = {
-  topNavigation: (props: NavigationScreenProps): TopNavigationElement => {
+const EcommerceMenuTopNavigationParams: any = {
+  header: (props: NavigationScreenProps): TopNavigationElement => {
     const state: NavigationRouteState = getCurrentRouteState(props.navigation);
 
     const onBackPress = (): void => {
@@ -70,10 +66,25 @@ const EcommerceMenuTopNavigationParams: TopNavigationParams = {
 
 const MenuBottomNavigationParams: BottomNavigationParams = {
   bottomNavigation: (props: NavigationScreenProps): BottomNavigationElement => {
-    return (
-      <MenuContainer {...props} />
-    );
+    return <MenuContainer {...props} />;
   },
+};
+
+export const MenuNavigatorDefaultOptions = props => {
+  const state: NavigationRouteState = getCurrentRouteState(props.navigation);
+
+  return {
+    header: (
+      <TopNavigationBar
+        {...props}
+        title={state.routeName}
+        backIcon={!props.navigation.isFirstRouteInParent() && ArrowIosBackFill}
+        onBackPress={() => {
+          props.navigation.goBack(null);
+        }}
+      />
+    ),
+  };
 };
 
 export const RootNavigatorParams: NavigationParams = {
@@ -105,6 +116,9 @@ export const WalkthroughNavigatorParams: NavigationParams = {
   ...MenuTopNavigationParams,
 };
 
+// Just to demonstrate
+export const EcommerceNavigatorOptions = EcommerceMenuTopNavigationParams;
+
 export const EcommerceNavigatorParams: NavigationParams = {
   ...EcommerceMenuTopNavigationParams,
 };
@@ -116,5 +130,3 @@ export const NavigationNavigatorParams: NavigationParams = {
 export const ComponentShowcaseNavigatorParams: NavigationParams = {
   ...MenuTopNavigationParams,
 };
-
-

--- a/src/core/navigation/routes.tsx
+++ b/src/core/navigation/routes.tsx
@@ -10,6 +10,7 @@ import {
   LayoutsContainer,
   ComponentsContainer,
   ThemesContainer,
+  MenuContainer,
 } from '@src/containers/menu';
 import {
   ArticlesContainer,
@@ -104,19 +105,27 @@ import {
   ComponentShowcaseNavigatorParams,
   WalkthroughNavigatorParams,
   NavigationNavigatorParams,
+  MenuNavigatorDefaultOptions,
+  EcommerceNavigatorOptions,
 } from './navigationParams';
 import { BottomNavigationBar } from './components/bottomNavigationBar.component';
 import { getCurrentRouteState } from './routeUtil';
 
-const HeadingNavigationOptions = ({ navigation }) => {
+import { Alert } from 'react-native';
+import { NavigationParams, NavigationScreenProps } from 'react-navigation';
+import { EcommerceHeader } from '@src/components/ecommerce';
 
+const HeadingNavigationOptions = ({ navigation }) => {
   const header = (headerProps: HeaderProps): TopNavigationElement | null => {
     const { params } = getCurrentRouteState(navigation);
 
     return params && params.topNavigation && params.topNavigation(headerProps);
   };
 
-  return { ...navigation, header };
+  return {
+    ...navigation,
+    // ...(header ? { header } : null)
+  };
 };
 
 const NavigationNavigator: ReactNavigationContainer = createStackNavigator(
@@ -128,51 +137,7 @@ const NavigationNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
-);
-
-const EcommerceNavigator: ReactNavigationContainer = createStackNavigator(
-  {
-    ['Ecommerce']: {
-      screen: EcommerceContainer,
-      params: MenuNavigatorParams,
-    },
-    ['Add New Card']: {
-      screen: AddNewCardContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Payment']: {
-      screen: PaymentContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Products List']: {
-      screen: ProductsListContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Product Details']: {
-      screen: ProductDetailsContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Shopping Cart']: {
-      screen: ShoppingCartContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Rent Apartment']: {
-      screen: RentApartmentContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Movie Details']: {
-      screen: MovieDetailsContainer,
-      params: EcommerceNavigatorParams,
-    },
-    ['Book Details']: {
-      screen: BookDetailsContainer,
-      params: EcommerceNavigatorParams,
-    },
-  },
-  {
-    headerMode: 'none',
-  },
+  }
 );
 
 const WalkthroughNavigator: ReactNavigationContainer = createStackNavigator(
@@ -184,7 +149,7 @@ const WalkthroughNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const DashboardsNavigator: ReactNavigationContainer = createStackNavigator(
@@ -204,7 +169,7 @@ const DashboardsNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const MessagingNavigator: ReactNavigationContainer = createStackNavigator(
@@ -230,7 +195,7 @@ const MessagingNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const ArticlesNavigator: ReactNavigationContainer = createStackNavigator(
@@ -270,7 +235,7 @@ const ArticlesNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const SocialNavigator: ReactNavigationContainer = createStackNavigator(
@@ -331,27 +296,7 @@ const SocialNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
-);
-
-const AuthNavigator: ReactNavigationContainer = createStackNavigator(
-  {
-    ['Auth']: AuthContainer,
-    ['Sign In 1']: SignIn1Container,
-    ['Sign In 2']: SignIn2Container,
-    ['Sign In 3']: SignIn3Container,
-    ['Sign In 4']: SignIn4Container,
-    ['Sign In 5']: SignIn5Container,
-    ['Sign Up 1']: SignUp1Container,
-    ['Sign Up 2']: SignUp2Container,
-    ['Sign Up 3']: SignUp3Container,
-    ['Sign Up 4']: SignUp4Container,
-    ['Forgot Password']: ForgotPasswordContainer,
-  },
-  {
-    headerMode: 'none',
-    initialRouteParams: MenuNavigatorParams,
-  },
+  }
 );
 
 const ThemesNavigator: ReactNavigationContainer = createStackNavigator(
@@ -363,7 +308,7 @@ const ThemesNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const ComponentsNavigator: ReactNavigationContainer = createStackNavigator(
@@ -435,41 +380,98 @@ const ComponentsNavigator: ReactNavigationContainer = createStackNavigator(
   },
   {
     headerMode: 'none',
-  },
+  }
 );
 
 const LayoutsNavigator: ReactNavigationContainer = createStackNavigator(
   {
-    ['Layouts']: {
-      screen: LayoutsContainer,
-      params: { ...RootNavigatorParams, ...MenuNavigatorParams },
-    },
-    ['Auth']: AuthNavigator,
+    ['Layouts']: LayoutsContainer,
+    ['Auth']: AuthContainer,
+    ['Ecommerce']: EcommerceContainer,
     ['Social']: SocialNavigator,
     ['Articles']: ArticlesNavigator,
     ['Messaging']: MessagingNavigator,
     ['Dashboards']: DashboardsNavigator,
     ['Walkthrough']: WalkthroughNavigator,
-    ['Ecommerce']: EcommerceNavigator,
     ['Navigation']: NavigationNavigator,
-  }, {
-    headerMode: 'none',
   },
+  {
+    defaultNavigationOptions: MenuNavigatorDefaultOptions,
+  }
 );
 
-const MenuNavigator: ReactNavigationContainer = createBottomTabNavigator({
-  ['Layouts']: LayoutsNavigator,
-  ['Components']: ComponentsNavigator,
-  ['Themes']: ThemesNavigator,
-}, {
-  tabBarComponent: BottomNavigationBar,
-});
-
-const AppNavigator: ReactNavigationContainer = createStackNavigator({
-  ['Home']: {
-    screen: MenuNavigator,
-    navigationOptions: HeadingNavigationOptions,
+const MenuNavigator: ReactNavigationContainer = createBottomTabNavigator(
+  {
+    ['Layouts']: LayoutsNavigator,
+    ['Components']: ComponentsNavigator,
+    ['Themes']: ThemesNavigator,
   },
-});
+  {
+    tabBarComponent: MenuContainer,
+  }
+);
 
-export const Router: ReactNavigationContainer = createAppContainer(AppNavigator);
+const AuthExamples = {
+  ['Sign In 1']: SignIn1Container,
+  ['Sign In 2']: SignIn2Container,
+  ['Sign In 3']: SignIn3Container,
+  ['Sign In 4']: SignIn4Container,
+  ['Sign In 5']: SignIn5Container,
+  ['Sign Up 1']: SignUp1Container,
+  ['Sign Up 2']: SignUp2Container,
+  ['Sign Up 3']: SignUp3Container,
+  ['Sign Up 4']: SignUp4Container,
+  ['Forgot Password']: ForgotPasswordContainer,
+};
+
+const EcommerceExamples = {
+  ['Add New Card']: {
+    screen: AddNewCardContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Payment']: {
+    screen: PaymentContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Products List']: {
+    screen: ProductsListContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Product Details']: {
+    screen: ProductDetailsContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Shopping Cart']: {
+    screen: ShoppingCartContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Rent Apartment']: {
+    screen: RentApartmentContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Movie Details']: {
+    screen: MovieDetailsContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+  ['Book Details']: {
+    screen: BookDetailsContainer,
+    navigationOptions: EcommerceNavigatorOptions,
+  },
+};
+
+const AppNavigator: ReactNavigationContainer = createStackNavigator(
+  {
+    ['Home']: MenuNavigator,
+    ...AuthExamples,
+    ...EcommerceExamples,
+  },
+  {
+    defaultNavigationOptions: {
+      header: null,
+    },
+  }
+);
+
+export const Router: ReactNavigationContainer = createAppContainer(
+  AppNavigator
+);


### PR DESCRIPTION
This isn't intended to be merged directly in, but instead I just wanted to show what you could do to change the navigation structure to be a lot simpler and also work more nicely.

Right now there is one navigation bar at the root which is controlled by searching through params in nested routes. We do the same with the bottom tab bar to hide it when necessary.

I consider controller navigation elements through nested route info to be an escape hatch - if you absolutely need to do it, you can do it similar to how you have done it here. But ideally you can get the behavior you want by carefully structuring your navigators and just configuring the parent navigator itself directly.

Notice that in this PR I moved the screens for auth and ecommerce to the root stack. For those screens I also set `defaultNavigationOptions` so the header is configured as we want them to be - it's `null` in auth screens and we have the standard ecommerce header in the ecommerce section. By putting this at the root, we don't need to hide the tab bar or navigation bar (along with the slight layout jank that comes with this), instead the screens just nicely slide in on top. We can get rid of the stack navigator for each other section and do this same thing, and we can stop using params to control the top level navigator header and bottom navigation bar.