### PR TITLE
fix : error thrown if onChangeText is undefined in validationInput

### DIFF
--- a/src/components/common/validationInput.component.tsx
+++ b/src/components/common/validationInput.component.tsx
@@ -41,9 +41,9 @@ class ValidationInputComponent extends React.Component<ValidationInputProps, Sta
     const becomeValid: boolean = !this.isValid(oldValue) && this.isValid(newValue);
     const becomeInvalid: boolean = !this.isValid(newValue) && this.isValid(oldValue);
 
-    if (becomeValid) {
+    if (becomeValid && this.props.onChangeText) {
       this.props.onChangeText(newValue);
-    } else if (becomeInvalid) {
+    } else if (becomeInvalid && this.props.onChangeText) {
       this.props.onChangeText(undefined);
     }
   }


### PR DESCRIPTION
Hi, i am using ui-kitten in a javascript project. 
While I was creating a javascript version of component validationInput, i encountered an error when onChangeText was undefined in validationInput.
I realize that this might not be the usual case to use an input field without using it's value, but still.
Steps to reproduce:
`<ValidationInput validator={EmailValidator} />`