### PR TITLE
fix(containers): update containers to fit ui-kitten 4.2

### DIFF
--- a/src/components/social/feed/feedActivityBar.component.tsx
+++ b/src/components/social/feed/feedActivityBar.component.tsx
@@ -67,8 +67,8 @@ class FeedActivityBarComponent extends React.Component<FeedActivityBarProps> {
         <Button
           style={themedStyle.addButton}
           textStyle={textStyle.button}
+          appearance='ghost'
           size='giant'
-          status='white'
           icon={this.renderAddIcon}
           onPress={this.onAddButtonPress}>
           Add Training

--- a/src/containers/components/button/button.container.tsx
+++ b/src/containers/components/button/button.container.tsx
@@ -5,6 +5,7 @@ import { Showcase } from '../common/showcase.component';
 import { ShowcaseSection } from '../common/showcaseSection.component';
 import { ShowcaseItem } from '../common/showcaseItem.component';
 import {
+  BasicButton,
   DangerButton,
   DefaultButton,
   DisabledButton,
@@ -22,7 +23,6 @@ import {
   SuccessButton,
   TinyButton,
   WarningButton,
-  WhiteButton,
 } from './showcase';
 
 export class ButtonContainer extends React.Component<NavigationStackScreenProps> {
@@ -90,8 +90,8 @@ export class ButtonContainer extends React.Component<NavigationStackScreenProps>
           <ShowcaseItem title='Danger'>
             <DangerButton style={styles.component}/>
           </ShowcaseItem>
-          <ShowcaseItem title='White'>
-            <WhiteButton style={styles.component}/>
+          <ShowcaseItem title='Basic'>
+            <BasicButton style={styles.component}/>
           </ShowcaseItem>
         </ShowcaseSection>
       </Showcase>

--- a/src/containers/components/button/showcase/basicButton.component.tsx
+++ b/src/containers/components/button/showcase/basicButton.component.tsx
@@ -6,10 +6,10 @@ import {
 
 type ButtonElement = React.ReactElement<ButtonProps>;
 
-export const WhiteButton = (props?: ButtonProps): ButtonElement => {
+export const BasicButton = (props?: ButtonProps): ButtonElement => {
   return (
     <Button
-      status='white'
+      status='basic'
       {...props}>
       BUTTON
     </Button>

--- a/src/containers/components/button/showcase/index.ts
+++ b/src/containers/components/button/showcase/index.ts
@@ -15,4 +15,4 @@ export { SuccessButton } from './successButton.component';
 export { InfoButton } from './infoButton.component';
 export { WarningButton } from './warningButton.component';
 export { DangerButton } from './dangerButton.component';
-export { WhiteButton } from './whiteButton.component';
+export { BasicButton } from './basicButton.component';

--- a/src/containers/layouts/articles/articleList4/articleList4.component.tsx
+++ b/src/containers/layouts/articles/articleList4/articleList4.component.tsx
@@ -89,7 +89,7 @@ class ArticleList4Component extends React.Component<ArticleList4Props> {
           <Button
             style={themedStyle.readButton}
             textStyle={textStyle.button}
-            status='white'
+            status='control'
             onPress={this.onReadButtonPress}>
             READ
           </Button>

--- a/src/containers/layouts/auth/signIn5/signIn5.component.tsx
+++ b/src/containers/layouts/auth/signIn5/signIn5.component.tsx
@@ -117,7 +117,6 @@ class SignIn5Component extends React.Component<SignIn5Props, State> {
             </Text>
           </View>
           <TabView
-            style={themedStyle.tabView}
             tabBarStyle={themedStyle.tabBar}
             indicatorStyle={themedStyle.tabViewIndicator}
             selectedIndex={this.state.selectedTabIndex}
@@ -181,10 +180,10 @@ export const SignIn5 = withStyles(SignIn5Component, (theme: ThemeType) => ({
   },
   tabContentContainer: {
     marginVertical: 8,
+    paddingHorizontal: 16,
   },
   tabView: {
     flex: 1,
-    paddingHorizontal: 16,
   },
   tabBar: {
     backgroundColor: 'transparent',

--- a/src/containers/layouts/social/profile7/profile7.component.tsx
+++ b/src/containers/layouts/social/profile7/profile7.component.tsx
@@ -112,7 +112,7 @@ class Profile7Component extends React.Component<Profile7Props> {
             <Button
               style={themedStyle.messageButton}
               textStyle={textStyle.button}
-              status='white'
+              status='control'
               icon={MessageCircleIconFill}
               onPress={this.onMessagePress}>
               MESSAGE


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/kittenTricks/blob/master/CONTRIBUTING.md) guide.

 #### Short description of what this resolves:

- Replaces `white` buttons with `basic`, `control` or `ghost`
- Fixes tab-view in Sign In 5 container